### PR TITLE
Automate GitHub Pages build with GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: GitHub Pages
+name: GitHub Pages Deploy
 on:
   push:
     branches:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,22 @@
+name: GitHub Pages
+on:
+  push:
+    branches:
+      - main
+jobs:
+  gh-pages-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+        bundler-cache: true 
+    - name: Jekyll Build
+      run: bundle exec jekyll build
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        personal_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_site

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [railsdoc.github.io](https://railsdoc.github.io/) 
 
 [![Build Status](https://travis-ci.com/railsdoc/railsdoc.github.io.svg?branch=main)](https://travis-ci.com/railsdoc/railsdoc.github.io)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/c964029a-6d5a-4f3a-95e9-d35830a2fe83/deploy-status)](https://app.netlify.com/sites/railsdoc-preview/deploys)
 
 railsdoc.github.io is yet another Rails API documentation website.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [railsdoc.github.io](https://railsdoc.github.io/) 
 
-[![Build Status](https://travis-ci.com/railsdoc/railsdoc.github.io.svg?branch=page-source)](https://travis-ci.com/railsdoc/railsdoc.github.io)
+[![Build Status](https://travis-ci.com/railsdoc/railsdoc.github.io.svg?branch=main)](https://travis-ci.com/railsdoc/railsdoc.github.io)
 
 railsdoc.github.io is yet another Rails API documentation website.
 


### PR DESCRIPTION
- REAMDE badge update (page-source → main)
- Automate gh-pages build with GitHub pages
  - using [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)