### PR TITLE
JS Libraries Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [railsdoc.github.io](https://railsdoc.github.io/) 
 
-[![Build Status](https://travis-ci.com/railsdoc/railsdoc.github.io.svg?branch=main)](https://travis-ci.com/railsdoc/railsdoc.github.io)
+[![CI](https://github.com/railsdoc/railsdoc.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/railsdoc/railsdoc.github.io/actions/workflows/ci.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/c964029a-6d5a-4f3a-95e9-d35830a2fe83/deploy-status)](https://app.netlify.com/sites/railsdoc-preview/deploys)
 
 railsdoc.github.io is yet another Rails API documentation website.

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   <link href="/assets/css/style.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/styles/monokai.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/monokai.min.css">
   <link rel="apple-touch-icon" href="icon.png">
   <meta name="theme-color" content="#fafafa">
   <link href="https://fonts.googleapis.com/css?family=Asap" rel="stylesheet">
@@ -59,8 +59,8 @@
   </div>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.0/anchor.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>
 </body>
 </html>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -59,8 +59,8 @@
   </div>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.1/anchor.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.0/anchor.min.js"></script>
   <script src="/assets/js/app.js"></script>
 </body>
 </html>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -59,7 +59,7 @@
   </div>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.2/anchor.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.1/anchor.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>
 </body>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -58,7 +58,7 @@
     </div>
   </div>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.2/anchor.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -4,7 +4,7 @@ $(() => {
   anchors.add();
 
   // highlight.js
-  hljs.initHighlighting();
+  hljs.highlightAll();
 
   $(".sidebar-sticky .icon").on("click", function (e) {
     $(this).siblings("ul").toggle();


### PR DESCRIPTION
- Update CI Badge
- Bump JS libraries
  - jQuery: 3.5.1→3.6.0
  - anchor-js: 4.2.2→4.3.0
  - highlight.js: 10.3.1→10.7.2