### PR TITLE
Better search experience: shortcut for search and auto-complete the query

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -28,7 +28,7 @@
   <header class="navbar navbar-dark navbar-expand bg-dark flex-md-nowrap p-0 shadow sticky-header">
     <a class="navbar-brand col-sm-3 col-md-2 mr-0" href="/">{{ site.title }}</a>
     <form class="w-100 d-none d-md-flex" action="/search" method="get">
-      <input class="form-control form-control-dark" type="text" placeholder="Search" aria-label="Search" name="q">
+      <input id="search-form" class="form-control form-control-dark" type="text" placeholder="Search" aria-label="Search" name="q">
     </form>
 
     <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex px-1">

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -76,5 +76,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.0/anchor.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>
+  <script src="/assets/js/search.js"></script>
 </body>
 </html>

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -1,5 +1,10 @@
 $(() => {
   const searchForm = document.getElementById("search-form")
+  const searchValue = (new URLSearchParams(location.search)).get("q")
+
+  if (searchValue) {
+    searchForm.value = searchValue
+  }
 
   addEventListener("keydown", (e) => {
     switch (e.key) {

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -1,0 +1,19 @@
+$(() => {
+  const searchForm = document.getElementById("search-form")
+
+  addEventListener("keydown", (e) => {
+    switch (e.key) {
+      case '/':
+        if (document.activeElement === searchForm) break
+
+        e.preventDefault()
+        searchForm.focus()
+        break
+      case 'Escape':
+        if (document.activeElement === searchForm) {
+          searchForm.blur()
+        }
+        break
+    }
+  })
+});


### PR DESCRIPTION
closes #3

- Add search shortcut (Focusing search form on pressing `/`, unfocusing on `Escape`)
- If there's a query (`?q=search_text`), set the value to search input