### PR TITLE
feat: Add SQL as a language for highlight.js

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -5,12 +5,13 @@ $(() => {
 
   // highlight.js
   hljs.configure({
-    languages: ['ruby', 'html', 'bash']
+    languages: ['ruby', 'html', 'bash', 'sql']
   });
   hljs.highlightAll();
 
   $("#navigation").load(`${config.rootPath}navigation.html`, function() {
     $(".sidebar-sticky .icon").on("click", function (e) {
+      e.preventDefault();
       $(this).siblings("ul").toggle();
       this.classList.toggle("icon-opened");
     });


### PR DESCRIPTION
## Description

Add SQL as a language for highlight.js

ref. https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md

## before

URL: https://railsdoc.github.io/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_index

<img width="825" alt="image" src="https://github.com/railsdoc/railsdoc.github.io/assets/803398/b2578293-0d61-4ca0-843e-d2382f1fc222">

## After

https://deploy-preview-132--railsdoc-preview.netlify.app/classes/activerecord/connectionadapters/schemastatements#method-i-add_index

<img width="838" alt="image" src="https://github.com/railsdoc/railsdoc.github.io/assets/803398/6ef4544c-52fe-4bb6-8730-3cb3168c7c63">
