### PR TITLE
Use monospace font for signatures

### DIFF
--- a/src/_sass/railsdoc.scss
+++ b/src/_sass/railsdoc.scss
@@ -170,6 +170,14 @@ code {
   }
 }
 
+// FIXME: Wrap method with `code` tag in sdoc
+.method {
+  h3 {
+    font-family: monospace;
+    font-size: 1.3rem;
+  }
+}
+
 #content {
   $hacky-div-height: 4rem;
 

--- a/src/_sass/railsdoc.scss
+++ b/src/_sass/railsdoc.scss
@@ -195,6 +195,15 @@ code {
 
   .attr-name {
     font-weight: bold;
+    font-family: monospace;
+  }
+
+  .attr-value {
+    font-family: monospace;
+  }
+
+  .attr-rw {
+    font-family: monospace;
   }
 }
 


### PR DESCRIPTION
<img width="600" alt="image" src="https://github.com/railsdoc/railsdoc.github.io/assets/803398/664c88ef-cbeb-4854-8538-16fa8b45cc2d">

<img width="467" alt="image" src="https://github.com/railsdoc/railsdoc.github.io/assets/803398/c7714339-7585-4e78-acdf-ce37f343a885">

