### PR TITLE
fix: Fix CI build (modify matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby-version: 2.7
-            build-rails-versions: "5.2"
-          - ruby-version: 3.0
-            build-rails-versions: "6.0,6.1"
-          - ruby-version: 3.3
-            build-rails-versions: "7.0,7.1,7.2"
+          - ruby-version: "2.7"
+            build-rails-versions: "5.2,6.0,6.1,7.0"
+          - ruby-version: "3.3"
+            build-rails-versions: "7.1,7.2"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ def generate_rails_rdoc
       gemfile.gsub!(/"sdoc".*$/, %("sdoc", github: "toshimaru/sdoc", branch: "#{MY_SDOC_BRANCH}"))
       File.write('Gemfile', gemfile)
 
-      sh 'bundle install && bundle update sdoc'
+      sh 'bundle install --path vendor/bundle && bundle update sdoc'
       rm_rf 'doc'
       sh 'bundle exec rake rdoc'
     end


### PR DESCRIPTION
## Updated Test Matrix

| Ruby Version | Rails Versions       |
|--------------|----------------------|
| 2.7          | 5.2, 6.0, 6.1, 7.0   |
| 3.3          | 7.1, 7.2             |

## Changes

- Update Gemfile.lock
- Add `--path vendor/bundle` to fix the following error

```
The installation path is insecure. Bundler cannot continue.
/opt/hostedtoolcache/Ruby/3.3.9/x64/lib/ruby/gems/3.3.0/gems is world-writable
(without sticky bit).
Bundler cannot safely replace gems in world-writeable directories due to
potential vulnerabilities.
Please change the permissions of this directory or choose a different install
path.
rake aborted!
```

## Realted PR

- https://github.com/toshimaru/sdoc/pull/11
