### PR TITLE
chore: Remove `--path vendor/bundle` option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ def generate_rails_rdoc
       gemfile.gsub!(/"sdoc".*$/, %("sdoc", github: "toshimaru/sdoc", branch: "#{MY_SDOC_BRANCH}"))
       File.write('Gemfile', gemfile)
 
-      sh 'bundle install --path vendor/bundle && bundle update sdoc'
+      sh 'bundle install && bundle update sdoc'
       rm_rf 'doc'
       sh 'bundle exec rake rdoc'
     end


### PR DESCRIPTION
Related PR: #180

This pull request makes a minor update to the Rake task for generating Rails documentation. The change simplifies the `bundle install` command by removing the custom installation path.

* Updated the `generate_rails_rdoc` task in `Rakefile` to run `bundle install` without the `--path vendor/bundle` option, streamlining dependency installation.