### PR TITLE
Bump anchor.js from 4.3 to 5.0 / Bump highlight.js from 11.9 to 11.11

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
   <link href="/assets/css/style.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/monokai.min.css">
   <link rel="apple-touch-icon" href="icon.png">
   <meta name="theme-color" content="#fafafa">
   <link href="https://fonts.googleapis.com/css?family=Asap" rel="stylesheet">
@@ -71,7 +71,7 @@
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js" integrity="sha512-byAcNWVEzFfu+tZItctr+WIMUJvpzT2kokkqcBq+VsrM3OrC5Aj9E2gh+hHpU0XNA3wDmX4sDbV5/nkhvTrj4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>
   <script src="/assets/js/search.js"></script>
 </body>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -70,7 +70,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.1/anchor.min.js" integrity="sha512-zPB79j2C+3sFS9zcA3vg/z6bVKzJVEyu9pY5w89akQRys76zpAT2t6S3wZKla3QQ14O5l/Yt0RUQ/DHXx82Y5g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js" integrity="sha512-byAcNWVEzFfu+tZItctr+WIMUJvpzT2kokkqcBq+VsrM3OrC5Aj9E2gh+hHpU0XNA3wDmX4sDbV5/nkhvTrj4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
   <script src="/assets/js/app.js"></script>
   <script src="/assets/js/search.js"></script>

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,8 +1,9 @@
-$(() => {
-  // anchor-js
+document.addEventListener('DOMContentLoaded', (event) => {
   anchors.options.visible = 'always';
   anchors.add();
+});
 
+$(() => {
   // highlight.js
   hljs.configure({
     languages: ['ruby', 'html', 'bash', 'sql']

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener('DOMContentLoaded', () => {
   anchors.options.visible = 'always';
   anchors.add();
 });


### PR DESCRIPTION
This pull request updates third-party dependencies and improves how scripts are initialized on the site. The main changes are version upgrades for `highlight.js` and `anchor-js`, and a refactor of the script initialization to use modern event listeners.

**Dependency Upgrades:**
* Upgraded `highlight.js` from version 11.9.0 to 11.11.1 in both the stylesheet and script includes in `default.html` for improved syntax highlighting and bug fixes. [[1]](diffhunk://#diff-447bcccac4c91994d26e8d28ab4d15308378a59534c453a4f722066fda822058L8-R8) [[2]](diffhunk://#diff-447bcccac4c91994d26e8d28ab4d15308378a59534c453a4f722066fda822058L73-R74)
* Upgraded `anchor-js` from version 4.3.1 to 5.0.0 in `default.html` for better anchor link support and security improvements.

**Script Initialization Improvements:**
* Refactored anchor-js initialization in `app.js` to use `DOMContentLoaded` instead of jQuery’s document ready, ensuring compatibility with modern browsers and best practices.
* Kept highlight.js initialization under jQuery’s document ready for legacy compatibility.