### PR TITLE
style: Use darker red for anchorjs link

### DIFF
--- a/src/_sass/railsdoc.scss
+++ b/src/_sass/railsdoc.scss
@@ -170,12 +170,17 @@ code {
   }
 }
 
-// FIXME: Wrap method with `code` tag in sdoc
 .method {
-  h3 {
-    font-family: monospace;
-    font-size: 1.3rem;
-  }
+    h3 {
+        font-family: monospace;
+        font-size: 1.3rem;
+    }
+
+    .description,
+    .method__aka,
+    .method__source {
+        margin-left: 1em;
+    }
 }
 
 #content {

--- a/src/_sass/railsdoc.scss
+++ b/src/_sass/railsdoc.scss
@@ -243,10 +243,10 @@ code {
 }
 
 .anchorjs-link {
-  color: #AAAAAA;
+  color: $red;
 
   &:hover {
-    color: $red;
+    color: #ee0000;
     text-decoration: none;
   }
 }

--- a/src/_sass/railsdoc.scss
+++ b/src/_sass/railsdoc.scss
@@ -180,6 +180,10 @@ code {
     .method__aka,
     .method__source {
         margin-left: 1em;
+
+        @media (min-width: 768px) {
+            margin-left: 2em;
+        }
     }
 }
 

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,16 +1,16 @@
-document.addEventListener('DOMContentLoaded', () => {
-  anchors.options.visible = 'always';
+document.addEventListener("DOMContentLoaded", () => {
+  anchors.options = { visible: "always" };
   anchors.add();
 });
 
 $(() => {
   // highlight.js
   hljs.configure({
-    languages: ['ruby', 'html', 'bash', 'sql']
+    languages: ["ruby", "html", "bash", "sql"],
   });
   hljs.highlightAll();
 
-  $("#navigation").load(`${config.rootPath}navigation.html`, function() {
+  $("#navigation").load(`${config.rootPath}navigation.html`, () => {
     $(".sidebar-sticky .icon").on("click", function (e) {
       e.preventDefault();
       $(this).siblings("ul").toggle();
@@ -18,7 +18,7 @@ $(() => {
     });
     $(`.sidebar-content a[href='${window.location.pathname}']`)
       .attr("class", "active-link")
-      .parents('ul')
+      .parents("ul")
       .show();
-  })
+  });
 });


### PR DESCRIPTION
<img width="1017" height="534" alt="image" src="https://github.com/user-attachments/assets/5e480e5f-6500-4188-ad50-9878394a0a3f" />

---

This pull request updates both the JavaScript and SCSS files to improve code consistency, enhance the appearance of anchor links, and refine the layout of method documentation. The most important changes are grouped below.

**JavaScript code improvements:**

* Refactored the initialization of the `anchors` library in `app.js` for better clarity and consistency, changing the options assignment to use an object and updating quote usage. Also improved the jQuery selector code style for consistency.

**SCSS styling enhancements:**

* Adjusted the color of `.anchorjs-link` to use the `$red` variable and a specific red shade on hover, improving visual consistency with the site's color scheme.
* Improved the `.method` class styles by adding left margin to `.description`, `.method__aka`, and `.method__source` elements, with increased spacing on larger screens for better readability.
