### PR TITLE
feat: Open details tag on `hashchange` event

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 $(() => {
-  // highlight.js
+  // highlight.js configuration
   hljs.configure({
     languages: ["ruby", "html", "bash", "sql"],
   });

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", () => {
   anchors.options = { visible: "always" };
   anchors.add();
+
+  window.addEventListener("hashchange", openDetailsForHash);
+  openDetailsForHash();
 });
 
 $(() => {
@@ -9,19 +12,6 @@ $(() => {
     languages: ["ruby", "html", "bash", "sql"],
   });
   hljs.highlightAll();
-
-  // Open details that is at the same level as the target of the hash
-  window.addEventListener("hashchange", () => {
-    const target = document.querySelector(window.location.hash);
-    if (!target) return;
-
-    const siblingDetails = target
-      .closest("div.method")
-      ?.querySelector("details");
-    if (siblingDetails) {
-      siblingDetails.open = true;
-    }
-  });
 
   $("#navigation").load(`${config.rootPath}navigation.html`, () => {
     $(".sidebar-sticky .icon").on("click", function (e) {
@@ -35,3 +25,17 @@ $(() => {
       .show();
   });
 });
+
+// Open details that is at the same level as the target of the hash
+function openDetailsForHash() {
+  const hash = window.location.hash;
+  if (!hash) return;
+  const target = document.querySelector(hash);
+  if (!target) return;
+
+  const siblingDetails = target.closest("div.method")?.querySelector("details");
+  if (siblingDetails) {
+    siblingDetails.open = true;
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+}

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -10,6 +10,19 @@ $(() => {
   });
   hljs.highlightAll();
 
+  // Open details that is at the same level as the target of the hash
+  window.addEventListener("hashchange", () => {
+    const target = document.querySelector(window.location.hash);
+    if (!target) return;
+
+    const siblingDetails = target
+      .closest("div.method")
+      ?.querySelector("details");
+    if (siblingDetails) {
+      siblingDetails.open = true;
+    }
+  });
+
   $("#navigation").load(`${config.rootPath}navigation.html`, () => {
     $(".sidebar-sticky .icon").on("click", function (e) {
       e.preventDefault();

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -1,24 +1,24 @@
 $(() => {
-  const searchForm = document.getElementById("search-form")
-  const searchValue = (new URLSearchParams(location.search)).get("q")
+  const searchForm = document.getElementById("search-form");
+  const searchValue = new URLSearchParams(location.search).get("q");
 
   if (searchValue) {
-    searchForm.value = searchValue
+    searchForm.value = searchValue;
   }
 
-  addEventListener("keydown", (e) => {
+  window.addEventListener("keydown", (e) => {
     switch (e.key) {
-      case '/':
-        if (document.activeElement === searchForm) break
+      case "/":
+        if (document.activeElement === searchForm) break;
 
-        e.preventDefault()
-        searchForm.focus()
-        break
-      case 'Escape':
+        e.preventDefault();
+        searchForm.focus();
+        break;
+      case "Escape":
         if (document.activeElement === searchForm) {
-          searchForm.blur()
+          searchForm.blur();
         }
-        break
+        break;
     }
-  })
+  });
 });


### PR DESCRIPTION
This pull request improves the user experience in the documentation and search functionality by ensuring that detail sections automatically open when navigating to a hash link and by refining the search input behavior and code style.

Enhancements to navigation and detail sections:

* Added a new `openDetailsForHash` function in `app.js` that automatically opens the relevant `details` element and scrolls it into view when navigating to a hash link, both on initial load and when the hash changes. [[1]](diffhunk://#diff-5555e2ef602b5ab54b81fdec33e8b0e4b49301b6f5943debab6cfbe9c3197f96R4-R10) [[2]](diffhunk://#diff-5555e2ef602b5ab54b81fdec33e8b0e4b49301b6f5943debab6cfbe9c3197f96R28-R41)

Improvements to search functionality and code consistency:

* Updated `search.js` to use consistent code style (semicolon usage and double quotes), improved event listener attachment by explicitly using `window.addEventListener`, and ensured the search input is focused or blurred appropriately based on keyboard shortcuts (`/` and `Escape`).