### PR TITLE
Disable Git maintenance during Rails tag fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - name: fetch Rails tags
         working-directory: rails
         run: |
+          # Work around a Git 2.54 shallow-file race; remove when runners use Git 2.55+.
+          git config --local maintenance.auto false
           for version in $(echo "${{ matrix.build-rails-versions }}" | tr ',' ' '); do
             git fetch --depth=1 origin refs/tags/v${version}*:refs/tags/v${version}*
           done


### PR DESCRIPTION
closes: #223

## Summary

- disable automatic Git maintenance before fetching Rails version tags
- avoid the Git 2.54 shallow-file race in the older-version CI matrix
- document that the workaround can be removed once runners use Git 2.55+

## Validation

- parsed `.github/workflows/ci.yml` as YAML
- checked the shell snippet with `bash -n`
- ran `git diff --check`